### PR TITLE
Api key users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
+.coverage
+.npmrc
+.scannerwork
 node_modules
 npm-debug.log
-.npmrc
 package-lock.json
-.coverage
-.scannerwork
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [0.1.2] - 2017-02-18
+### Added
+- Add role and reference options to apiKey creation resource.
+
+### Fixed
+- Ensure that no core options are overridden with custom options.
+- Do not warn authentication disabled for an api resource when one authentication method is available.
+
+## [0.1.1] - 2017-02-17
 ### Added
 - Add coveralls badge
 - Core objects full unit tests coverage

--- a/README.md
+++ b/README.md
@@ -520,6 +520,8 @@ Must contain properties:
 * `authenticate` - API operation for requesting a new api key. This api point needs authentication as well, so, if your system  authentication is only api key based, you have to define an initial api key that could be used to request more in case it´s needed. This method supports _Json Web Token_ authentication as well, if it is implemented.
 	* `auth` - Authorization method for the `/api/auth/apikey` _POST_ api resource.
 	* `handler` - Operation handler for the `/api/auth/apikey` _POST_ api resource.
+		* Arguments:
+			* `userData` - An object containing `userName`, `role` and `reference`
 		* Should return a new api key.
 * `revoke` - API operation for removing an api key. This api resource needs authentication as well.
 	* `auth` - Authorization method for the `/api/auth/apikey` _DELETE_ api resource.

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -6,15 +6,17 @@ const Promise = require('bluebird')
 const bases = require('./bases')
 const utils = require('./utils')
 const serviceArguments = require('./arguments/service')
+const coreArguments = require('./arguments/core')
 const AboutOperations = require('./api/about/Operations')
 const aboutOpenApi = require('./api/about/openapi.json')
 const ConfigOperations = require('./api/config/Operations')
 const configOpenApi = require('./api/config/openapi.json')
 
 const extendServiceArguments = function (customConfig) {
+  const allServiceArguments = _.extend({}, coreArguments, serviceArguments)
   customConfig = customConfig || {}
   _.each(customConfig, (optionProperties, optionName) => {
-    if (serviceArguments[optionName]) {
+    if (allServiceArguments[optionName]) {
       throw new Error(utils.templates.compiled.cli.overwriteOptionError({
         optionName: optionName
       }))

--- a/lib/bases/server/api/Security.js
+++ b/lib/bases/server/api/Security.js
@@ -74,13 +74,14 @@ const Security = function (core, supportedMethods, authorizationRoles) {
   }
 
   const getSecurityMethods = function (securityDefinitions, routePath, httpMethod) {
-    return _.compact(_.uniq(_.map(securityDefinitions, (security) => {
+    const securityMethods = _.compact(_.uniq(_.map(securityDefinitions, (security) => {
       const method = _.keys(security)[0]
       if (_.keys(supportedMethods).indexOf(method) < 0) {
-        core.tracer.warn(templates.notImplementedAuthenticationMethod({
+        core.tracer.trace(templates.notImplementedAuthenticationMethod({
           method: method,
           supported: _.keys(supportedMethods)
-        }), templates.securityDisabledForRoute({
+        }), templates.securityMethodDisabledForRoute({
+          securityMethod: method,
           routePath: routePath,
           method: httpMethod
         }))
@@ -88,6 +89,15 @@ const Security = function (core, supportedMethods, authorizationRoles) {
       }
       return method
     })))
+
+    if (!securityMethods.length) {
+      core.tracer.warn(templates.securityDisabledForRoute({
+        routePath: routePath,
+        method: httpMethod
+      }))
+    }
+
+    return securityMethods
   }
 
   const getAuthDisabledRange = function (req) {

--- a/lib/bases/server/security/apikey/openapi.json
+++ b/lib/bases/server/security/apikey/openapi.json
@@ -28,6 +28,15 @@
                 "type": "object",
                 "properties": {
                   "userName": {
+                    "description": "User owner of the new api key",
+                    "type": "string"
+                  },
+                  "role": {
+                    "description": "Authorization role for the new api key",
+                    "type": "string"
+                  },
+                  "reference": {
+                    "description": "Identifier of the new api key, for later reference",
                     "type": "string"
                   }
                 },

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,6 +7,7 @@ const bases = require('./bases')
 const start = require('./cli/start')
 const stop = require('./cli/stop')
 const logs = require('./cli/logs')
+const coreArguments = require('./arguments/core')
 
 const extendCommands = function (commands, customConfig) {
   const baseCommands = {
@@ -25,7 +26,7 @@ const extendCommands = function (commands, customConfig) {
   })
 
   _.each(customConfig, (optionProperties, optionName) => {
-    if (baseCommands.start.options[optionName]) {
+    if (baseCommands.start.options[optionName] || coreArguments[optionName]) {
       throw new Error(utils.templates.compiled.cli.overwriteStartOptionError({
         optionName: optionName
       }))

--- a/lib/utils/templates/server.js
+++ b/lib/utils/templates/server.js
@@ -45,6 +45,7 @@ module.exports = {
   authorizationFailedError: 'Not authorized',
   wrongAuthenticationMethod: 'Authentication method "{{method}}" is not supported.{{#if supported.length}} Supported methods are: {{comma-separated supported}}.{{/if}}',
   notImplementedAuthenticationMethod: 'Authentication method "{{method}}" is not enabled.{{#if supported.length}} Enabled methods are: {{comma-separated supported}}.{{/if}}',
+  securityMethodDisabledForRoute: 'Security method "{{securityMethod}}" will be disabled for {{upperCase method}} requests to route "{{routePath}}"',
   securityDisabledForRoute: 'Security will be disabled for {{upperCase method}} requests to route "{{routePath}}"',
   malFormedAuthenticationMethodError: 'Authentication method "{{method}}" is malformed',
   disabledAuthenticationRequest: 'Request authentication disabled | {{req.ip}} | {{req.id}}',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domapic-microservice",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "WebAPI Microservice base for Domapic Node.js packages",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "main": "index.js",
   "keywords": [
     "microservice",
+    "domotic",
     "api",
     "openapi",
+    "openapi3",
     "service",
+    "error-handling",
     "ssl",
     "server",
     "authentication",
@@ -16,7 +19,9 @@
     "client",
     "tracer",
     "cli",
-    "process manager"
+    "commandline-interface",
+    "process manager",
+    "swagger-ui"
   ],
   "scripts": {
     "test": "./node_modules/istanbul/lib/cli.js cover ./node_modules/.bin/_mocha -- --recursive test",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=domapic
 sonar.projectKey=domapic-microservice
-sonar.projectVersion=0.1.0
+sonar.projectVersion=0.1.2
 
 sonar.sources=.
 sonar.exclusions=node_modules/**


### PR DESCRIPTION
* Add role and reference options to apiKey creation resource.
* Ensure that no core options are overridden with custom options.
* Do not warn authentication disabled for an api resource when one authentication method is available.