### PR TITLE
Package info to service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Move utility "utils.process.getUsedCommand" to "utils.usedCommand"
+- Promesify Service creation errors
 
 ## [0.1.2] - 2017-02-18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.0] - 2017-02-22
+### Added
+- Package info available from service.
+- Improved client errors traces.
+- Add utility "serviceType"
+
+### Changed
+- Move utility "utils.process.getUsedCommand" to "utils.usedCommand"
+
 ## [0.1.2] - 2017-02-18
 ### Added
 - Add role and reference options to apiKey creation resource.
@@ -21,7 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Ignore node_modules in Sonar-scanner
 
 ### Fixed
-- For package Info, read the property "homepage" from package.json, not "homePage".
+- For package info, read the property "homepage" from package.json, not "homePage".
 
 ## [0.1.0] - 2017-02-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Package info available from service.
 - Improved client errors traces.
-- Add utility "serviceType"
+- Add utility "serviceType".
 
 ### Changed
 - Move utility "utils.process.getUsedCommand" to "utils.usedCommand"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ WebAPI Microservice base for Domapic Node.js packages.
 * [Errors](#errors)
 * [Storage](#storage)
 * [Utils](#utils)
+* [Info](#info)
 * [Authentication](#authentication)
 	* [Api Key](#api-key)
 	* [Jwt](#jwt)
@@ -490,6 +491,27 @@ service.utils.serviceType('example-domapic-controller')
 // controller
 service.utils.serviceType('foo-example')
 // unrecognized
+```
+
+[back to top](#table-of-contents)
+
+---
+
+## Info
+
+Static object containing information about the package, from the `package.json` file.
+
+* `name` - Mandatory. The `package.json` must contain this property.
+* `type` - Domapic category for the package. It is calculated using the package name.
+	* Possible values are: `service`, `controller`, `plugin`, `unrecognized`
+* `version` - Mandatory. The `package.json` must contain this property.
+* `description` - Mandatory. The `package.json` must contain this property.
+* `homepage`
+* `author`
+* `license`
+
+```js
+console.log(service.info)
 ```
 
 [back to top](#table-of-contents)

--- a/README.md
+++ b/README.md
@@ -391,6 +391,7 @@ Consult [all available error constructors](lib/bases/core/Errors.js) and its cor
 In addition to error constructors, three methods are provided in the `errors` object. These methods are used internally by _domapic-microservice_ in order to map the returned errors to HTML errors and viceversa:
 
 * `isControlled` - Allows to know if error has been created with a custom error constructor
+	* `service.errors.isControlled(error)`
 	
 ```js
 const error = new service.errors.Conflict()
@@ -403,6 +404,7 @@ console.log(service.errors.isControlled(error))
 ```
 
 * `FromCode` - Returns an error created with the constructor correspondent to the provided html error status code:
+	* `service.errors.FromCode(code, message, [stack], [extraData])`
 	
 ```js
 return Promise.reject(new service.errors.FromCode(403, 'Custom message'))
@@ -414,6 +416,7 @@ return Promise.reject(new service.errors.FromCode(403, 'Custom message'))
 ```
 
 * `toHTML` - Returns a [_Boomified_](https://www.npmjs.com/package/boom) error correspondent to the used error constructor. Each error constructor is mapped to an specific status code, ready to be returned by the API:
+	* `service.errors.toHTML(error)`
 
 ```js
 const error = new service.errors.Forbidden()
@@ -476,8 +479,18 @@ console.log(templates.myTemplate1({
 // Value is: 123
 ```
 	* `compiled` - Set of precompiled templates, used internally.
-* `process`
-	* `getUsedCommand` - Used internally by CLI. Returns the command used to invoque it.
+* `usedCommand` - Used internally by CLI. Returns the command used to invoque it.
+* `serviceType` - Provided a package name, returns the correspondant domapic service type.
+```js
+service.utils.serviceType('example-domapic-service')
+// service
+service.utils.serviceType('example-domapic-plugin')
+// plugin
+service.utils.serviceType('example-domapic-controller')
+// controller
+service.utils.serviceType('foo-example')
+// unrecognized
+```
 
 [back to top](#table-of-contents)
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const cli = require('./lib/Cli')
+const cli = require('./lib/cli')
 const Service = require('./lib/Service')
 const utils = require('./lib/utils')
 

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -54,6 +54,7 @@ const Service = function (options) {
               client: client,
               config: core.config,
               errors: core.errors,
+              info: core.info,
               server: server,
               storage: core.storage,
               tracer: core.tracer,

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -14,20 +14,28 @@ const configOpenApi = require('./api/config/openapi.json')
 
 const extendServiceArguments = function (customConfig) {
   const allServiceArguments = _.extend({}, coreArguments, serviceArguments)
+  let error
   customConfig = customConfig || {}
   _.each(customConfig, (optionProperties, optionName) => {
     if (allServiceArguments[optionName]) {
-      throw new Error(utils.templates.compiled.cli.overwriteOptionError({
+      error = new Error(utils.templates.compiled.cli.overwriteOptionError({
         optionName: optionName
       }))
     }
   })
-  return _.extend({}, serviceArguments, customConfig)
+  if (error) {
+    return Promise.reject(error)
+  }
+  return Promise.resolve(_.extend({}, serviceArguments, customConfig))
 }
 
 const Service = function (options) {
   options = options || {}
-  return new bases.Arguments(extendServiceArguments(options.customConfig)).get()
+  return extendServiceArguments(options.customConfig)
+    .then(bases.Arguments)
+    .then((baseArgs) => {
+      return baseArgs.get()
+    })
     .then((args) => {
       const core = new bases.Core(args, 'service', options.packagePath)
       const server = new bases.Server(core)

--- a/lib/bases/Client.js
+++ b/lib/bases/Client.js
@@ -42,6 +42,10 @@ const Client = function (core) {
         traces.push({
           error: [templates.requestErrorTitle(), templates.receivedResponseInfoLog({request: request}), '\n', request.error]
         })
+      } else {
+        traces.push({
+          trace: [templates.requestErrorTitle(), templates.receivedResponseInfoLog({request: request}), '\n', request.error.extraData]
+        })
       }
 
       return core.tracer.group(traces)
@@ -184,7 +188,7 @@ const Client = function (core) {
             } else if (successResponses.indexOf(statusCode) < 0) {
               reject(new core.errors.FromCode(statusCode, templates.receivedErrorStatus({
                 statusCode: statusCode
-              })))
+              }), null, responseBody))
             } else {
               resolve(responseBody)
             }

--- a/lib/bases/core/Errors.js
+++ b/lib/bases/core/Errors.js
@@ -70,12 +70,13 @@ const Errors = function () {
   }
 
   const ErrorFactory = function (name, constructorName) {
-    const ErrorConstructor = function (message, stack) {
+    const ErrorConstructor = function (message, stack, extraData) {
       this.message = message
       this.name = name
       this.typeof = constructorName
       this.isDomapic = true
       this.stack = stack || (new Error()).stack
+      this.extraData = extraData
     }
 
     ErrorConstructor.prototype = Object.create(Error.prototype)
@@ -94,14 +95,14 @@ const Errors = function () {
 
   const byType = createConstructors()
 
-  const FromCode = function (code, message) {
+  const FromCode = function (code, message, stack, extraData) {
     let constructorName
     _.each(errors, (properties, errorName) => {
       if (code === properties.fromCode) {
         constructorName = errorName
       }
     })
-    return (constructorName && new byType[constructorName](message)) || new Error(message)
+    return (constructorName && new byType[constructorName](message, stack, extraData)) || new Error(message)
   }
 
   const toHTML = function (error) {

--- a/lib/bases/core/Info.js
+++ b/lib/bases/core/Info.js
@@ -5,10 +5,10 @@ const path = require('path')
 
 const fsExtra = require('fs-extra')
 
-const templatesUtils = require('../../utils/templates')
+const utils = require('../../utils')
 
 const Info = function (packagePath, errors) {
-  const templates = templatesUtils.compiled.info
+  const templates = utils.templates.compiled.info
   let packageJsonPath
   let packageJson
 
@@ -17,18 +17,6 @@ const Info = function (packagePath, errors) {
       throw new errors.BadData(templates.noNameFound())
     }
     return packageJson.name
-  }
-
-  // TODO, to core utils. Change expressions
-  const getType = function (packageJson) {
-    if (/-service$/.test(packageJson.name)) {
-      return 'service'
-    } else if (/-controller$/.test(packageJson.name)) {
-      return 'controller'
-    } else if (/-plugin$/.test(packageJson.name)) {
-      return 'plugin'
-    }
-    return 'unrecognized'
   }
 
   const getVersion = function (packageJson) {
@@ -71,7 +59,7 @@ const Info = function (packagePath, errors) {
 
   return {
     name: getName(packageJson),
-    type: getType(packageJson),
+    type: utils.serviceType(packageJson.name),
     version: getVersion(packageJson),
     description: getDescription(packageJson),
     homepage: getHomepage(packageJson),

--- a/lib/bases/core/Info.js
+++ b/lib/bases/core/Info.js
@@ -19,6 +19,7 @@ const Info = function (packagePath, errors) {
     return packageJson.name
   }
 
+  // TODO, to core utils. Change expressions
   const getType = function (packageJson) {
     if (/-service$/.test(packageJson.name)) {
       return 'service'

--- a/lib/cli/start.js
+++ b/lib/cli/start.js
@@ -14,7 +14,7 @@ const start = function (config, cli) {
     .then(() => {
       const templatesData = {
         name: config.name,
-        usedCommand: cli.utils.process.getUsedCommand()
+        usedCommand: cli.utils.usedCommand()
       }
       return cli.tracer.group([
         {info: templates.stopServiceHelp(templatesData)},

--- a/lib/cli/stop.js
+++ b/lib/cli/stop.js
@@ -13,7 +13,7 @@ const stop = function (config, cli) {
     })
     .then(() => {
       return cli.tracer.info(templates.startServiceHelp({
-        usedCommand: cli.utils.process.getUsedCommand(),
+        usedCommand: cli.utils.usedCommand(),
         name: config.name
       }))
     })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,8 +2,10 @@
 
 const templates = require('./utils/templates')
 const proc = require('./utils/process')
+const misc = require('./utils/misc')
 
 module.exports = {
   templates: templates,
-  process: proc
+  usedCommand: proc.usedCommand,
+  serviceType: misc.serviceType
 }

--- a/lib/utils/misc.js
+++ b/lib/utils/misc.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const serviceType = function (packageName) {
+  if (/-service$/.test(packageName)) {
+    return 'service'
+  } else if (/-controller$/.test(packageName)) {
+    return 'controller'
+  } else if (/-plugin$/.test(packageName)) {
+    return 'plugin'
+  }
+  return 'unrecognized'
+}
+
+module.exports = {
+  serviceType: serviceType
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domapic-microservice",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "WebAPI Microservice base for Domapic Node.js packages",
   "main": "index.js",
   "keywords": [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=domapic
 sonar.projectKey=domapic-microservice
-sonar.projectVersion=0.1.2
+sonar.projectVersion=0.2.0
 
 sonar.sources=.
 sonar.exclusions=node_modules/**

--- a/test/index.specs.js
+++ b/test/index.specs.js
@@ -1,0 +1,21 @@
+
+const test = require('./index')
+
+const index = require('../index.js')
+const Service = require('../lib/Service')
+const cli = require('../lib/cli')
+const utils = require('../lib/utils')
+
+test.describe('Index', () => {
+  test.it('should return the Service constructor', () => {
+    test.expect(index.Service).to.deep.equal(Service)
+  })
+
+  test.it('should return the cli method', () => {
+    test.expect(index.cli).to.deep.equal(cli)
+  })
+
+  test.it('should return the utils object', () => {
+    test.expect(index.utils).to.deep.equal(utils)
+  })
+})

--- a/test/lib/arguments/service.specs.js
+++ b/test/lib/arguments/service.specs.js
@@ -1,0 +1,31 @@
+
+const _ = require('lodash')
+const path = require('path')
+
+const test = require('../../index')
+
+const serviceArguments = require('../../../lib/arguments/service')
+
+test.describe('arguments -> service', () => {
+  const pathsOptions = ['sslCert', 'sslKey']
+
+  const testAbsolutePath = function (optionName) {
+    test.describe(optionName + ' path option', () => {
+      test.it('should be converted to absolute, if it is relative', () => {
+        const fooPath = 'testing'
+        const result = serviceArguments[optionName].coerce(fooPath)
+        test.expect(result).to.equal(path.resolve(process.cwd(), fooPath))
+      })
+
+      test.it('should not be converted, if it is already absolute', () => {
+        const fooPath = path.resolve(process.cwd(), 'testing')
+        const result = serviceArguments[optionName].coerce(fooPath)
+        test.expect(result).to.equal(fooPath)
+      })
+    })
+  }
+
+  _.each(pathsOptions, (optionName) => {
+    testAbsolutePath(optionName)
+  })
+})

--- a/test/lib/bases/Core.mocks.js
+++ b/test/lib/bases/Core.mocks.js
@@ -8,12 +8,13 @@ const configMocks = require('./core/Config.mocks')
 const processMocks = require('./Process.mocks')
 
 const Stub = function () {
-  const FooErrorConstructor = function (message, stack) {
+  const FooErrorConstructor = function (message, stack, extraData) {
     this.message = message
     this.name = 'Error'
     this.typeof = 'fooType'
     this.isDomapic = true
     this.stack = stack || (new Error()).stack
+    this.extraData = extraData
   }
 
   FooErrorConstructor.prototype = Object.create(Error.prototype)
@@ -32,7 +33,8 @@ const Stub = function () {
       debug: test.sinon.stub().usingPromise(Promise).resolves(),
       group: test.sinon.stub().usingPromise(Promise).resolves(),
       info: test.sinon.stub().usingPromise(Promise).resolves(),
-      log: test.sinon.stub().usingPromise(Promise).resolves()
+      log: test.sinon.stub().usingPromise(Promise).resolves(),
+      error: test.sinon.stub().usingPromise(Promise).resolves()
     },
     utils: {
       templates: {

--- a/test/lib/bases/Core.mocks.js
+++ b/test/lib/bases/Core.mocks.js
@@ -39,9 +39,8 @@ const Stub = function () {
         compile: test.sinon.stub().callsFake(utils.templates.compile),
         compiled: utils.templates.compiled
       },
-      process: {
-        getUsedCommand: test.sinon.stub().callsFake(utils.process.getUsedCommand)
-      }
+      usedCommand: test.sinon.stub().callsFake(utils.usedCommand),
+      serviceType: test.sinon.stub().callsFake(utils.servicetype)
     },
     errors: {
       isControlled: test.sinon.stub(),

--- a/test/lib/bases/core/Errors.specs.js
+++ b/test/lib/bases/core/Errors.specs.js
@@ -29,6 +29,19 @@ test.describe('Bases -> Core -> Errors', () => {
           const error = new Method('fooMessage', customError.stack)
           test.expect(error.stack).to.equal(customError.stack)
         })
+
+        test.it('should have an "isDomapic" property for controlled errors identification', () => {
+          const error = new Method('fooMessage')
+          test.expect(error.isDomapic).to.equal(true)
+        })
+
+        test.it('should return the extra data, if passed', () => {
+          const extraData = {
+            fooProperty: 'fooData'
+          }
+          const error = new Method('fooMessage', null, extraData)
+          test.expect(error.extraData).to.deep.equal(extraData)
+        })
       })
     }
   })
@@ -43,6 +56,20 @@ test.describe('Bases -> Core -> Errors', () => {
       const error = new errors.FromCode(1203, 'fooMessage')
       test.expect(error.isDomapic).to.be.undefined()
       test.expect(error.typeof).to.be.undefined()
+    })
+
+    test.it('should return the received stack, if passed', () => {
+      const customError = new Error('fooError')
+      const error = new errors.FromCode(501, 'fooMessage', customError.stack)
+      test.expect(error.stack).to.equal(customError.stack)
+    })
+
+    test.it('should return the extra data, if passed', () => {
+      const extraData = {
+        fooProperty: 'fooData'
+      }
+      const error = new errors.FromCode(501, 'fooMessage', null, extraData)
+      test.expect(error.extraData).to.deep.equal(extraData)
     })
   })
 


### PR DESCRIPTION
- Package info available from service.
- Improved client errors traces.
- Add utility "serviceType".
- Move utility "utils.process.getUsedCommand" to "utils.usedCommand".
- Promesify Service creation errors.