### PR TITLE
Add set method to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) 
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.3.0] - 2017-02-24
+### Added
+- Add set method to config.
+- Increased unit tests coverage.
+
+### Fixed
+- Fix async tests pattern in Config, Arguments and Process unit tests.
+
 ## [0.2.1] - 2017-02-22
 ### Fixed
 - Ensure response was received before save status code

--- a/lib/bases/core/Config.js
+++ b/lib/bases/core/Config.js
@@ -3,10 +3,14 @@
 const _ = require('lodash')
 const Promise = require('bluebird')
 
+const utils = require('../../utils')
+
 const UNSTORABLE_CONFIG = ['name', 'saveConfig']
 
 const Config = function (storage, args, errors) {
   let buildConfigPromise
+  let _config
+
   const checkDefaults = function (storedConfig) {
     let hasToUpdate
     _.each(args.defaults, (value, key) => {
@@ -52,15 +56,41 @@ const Config = function (storage, args, errors) {
     return buildConfigPromise
   }
 
+  const returnConfig = function (key) {
+    const configClone = JSON.parse(JSON.stringify(_config))
+    return Promise.resolve(key ? configClone[key] : configClone)
+  }
+
   const get = function (key) {
+    if (_config) {
+      return returnConfig(key)
+    }
     return buildConfig()
       .then((config) => {
-        return Promise.resolve(key ? config[key] : config)
+        _config = config
+        return returnConfig(key)
+      })
+  }
+
+  const set = function (key, value) {
+    if (!key) {
+      return Promise.reject(new errors.BadData(utils.templates.compiled.storage.invalidKeyError({
+        key: typeof key
+      })))
+    }
+    return get(key)
+      .then(() => {
+        return storage.set(key, value)
+      })
+      .then(() => {
+        _config[key] = value
+        return get(key)
       })
   }
 
   return {
-    get: get
+    get: get,
+    set: set
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domapic-microservice",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "WebAPI Microservice base for Domapic Node.js packages",
   "main": "index.js",
   "keywords": [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=domapic
 sonar.projectKey=domapic-microservice
-sonar.projectVersion=0.2.1
+sonar.projectVersion=0.3.0
 
 sonar.sources=.
 sonar.exclusions=node_modules/**

--- a/test/lib/bases/Core.specs.js
+++ b/test/lib/bases/Core.specs.js
@@ -16,29 +16,47 @@ test.describe('Bases -> Core', () => {
   const fooProcessName = 'testing'
   let core
 
-  test.beforeEach(() => {
-    test.sinon.stub(coreLib, 'Errors').returns(fooErrors)
-    test.sinon.stub(coreLib, 'Paths').returns(fooPaths)
-    test.sinon.stub(coreLib, 'Storage').returns(fooStorage)
-    test.sinon.stub(coreLib, 'Config').returns(fooConfig)
-    test.sinon.stub(coreLib, 'Tracer').returns(fooTracer)
-    test.sinon.stub(coreLib, 'Info').returns(fooInfo)
-    core = new Core(mocks.arguments.getResult, fooProcessName)
-  })
-
-  test.afterEach(() => {
+  const restoreStubs = function () {
     coreLib.Errors.restore()
     coreLib.Paths.restore()
     coreLib.Storage.restore()
     coreLib.Config.restore()
     coreLib.Tracer.restore()
     coreLib.Info.restore()
+  }
+
+  const initStubs = function () {
+    test.sinon.stub(coreLib, 'Errors').returns(fooErrors)
+    test.sinon.stub(coreLib, 'Paths').returns(fooPaths)
+    test.sinon.stub(coreLib, 'Storage').returns(fooStorage)
+    test.sinon.stub(coreLib, 'Config').returns(fooConfig)
+    test.sinon.stub(coreLib, 'Tracer').returns(fooTracer)
+    test.sinon.stub(coreLib, 'Info').returns(fooInfo)
+  }
+
+  test.beforeEach(() => {
+    initStubs()
+    core = new Core(mocks.arguments.getResult, fooProcessName)
+  })
+
+  test.afterEach(() => {
+    restoreStubs()
   })
 
   test.it('should create a new Errors instance', () => {
     test.expect(coreLib.Errors).to.have.been.calledWithNew()
     test.expect(coreLib.Errors.getCall(0).args[0]).to.be.undefined()
     test.expect(core.errors).to.deep.equal(fooErrors)
+  })
+
+  test.it('should create a new Info instance if packagePath option is provided, passing packagePath and errors', () => {
+    const fooPath = 'fooPath'
+    restoreStubs()
+    initStubs()
+    core = new Core(mocks.arguments.getResult, fooProcessName, fooPath)
+    test.expect(coreLib.Info).to.have.been.calledWithNew()
+    test.expect(coreLib.Info.getCall(0).args[0]).to.equal(fooPath)
+    test.expect(coreLib.Paths.getCall(0).args[1]).to.deep.equal(fooErrors)
   })
 
   test.it('should create a new Paths instance, passing options and errors', () => {


### PR DESCRIPTION
- Add set method to config.
- Increased unit tests coverage.
- Fix async tests pattern in Config, Arguments and Process unit tests.